### PR TITLE
Add 'c' to the meson project

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -1,3 +1,3 @@
-project('pyrime', 'cython', version: '0.0.7')
+project('pyrime', 'cython', 'c', version: '0.0.7')
 
 subdir('src/pyrime')


### PR DESCRIPTION
Using Cython requires both 'cython' and 'c' to be specified in the project()

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
	- Updated project configuration to support both Cython and C languages.
	- Maintained project version at 0.0.7.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->