### PR TITLE
➕️ Add native Windows build

### DIFF
--- a/src/pyrime/__init__.py
+++ b/src/pyrime/__init__.py
@@ -2,6 +2,7 @@ r"""Provide ``__version__`` for
 `importlib.metadata.version() <https://docs.python.org/3/library/importlib.metadata.html#distribution-versions>`_.
 """
 
+import os, sys
 from dataclasses import dataclass
 from enum import Enum, auto
 
@@ -9,6 +10,11 @@ __version__ = "@PROJECT_VERSION@"
 # wrong rime.distribution_version will result in error
 if "@" in __version__:
     __version__ = "0.0.1"
+
+if sys.platform == "win32":
+    lib_dir = os.environ.get("LIBRIME_LIB_DIR")
+    if lib_dir and os.path.isdir(lib_dir):
+        os.add_dll_directory(lib_dir)
 
 
 class LogLevel(Enum):

--- a/src/pyrime/__init__.py
+++ b/src/pyrime/__init__.py
@@ -2,7 +2,8 @@ r"""Provide ``__version__`` for
 `importlib.metadata.version() <https://docs.python.org/3/library/importlib.metadata.html#distribution-versions>`_.
 """
 
-import os, sys
+import os
+import sys
 from dataclasses import dataclass
 from enum import Enum, auto
 

--- a/src/pyrime/meson.build
+++ b/src/pyrime/meson.build
@@ -1,5 +1,28 @@
-rime_dep = dependency('rime')
-deps = [rime_dep]
+# Try pkg-config first (Linux/macOS), fall back to env vars (Windows)
+rime_dep = dependency('rime', required: false)
+
+if rime_dep.found()
+  deps = [rime_dep]
+  rime_inc_dir = run_command(
+    'pkg-config', '--variable=includedir', 'rime', check: true,
+  ).stdout().strip()
+else
+  # Windows: read from LIBRIME_INCLUDE_DIR / LIBRIME_LIB_DIR
+  rime_inc_dir = run_command(
+    'cmd', '/c', 'echo', '%LIBRIME_INCLUDE_DIR%', check: true,
+  ).stdout().strip().replace('\\', '/')
+  rime_lib_dir = run_command(
+    'cmd', '/c', 'echo', '%LIBRIME_LIB_DIR%', check: true,
+  ).stdout().strip().replace('\\', '/')
+
+  cc = meson.get_compiler('c')
+  rime_dep = declare_dependency(
+    include_directories: include_directories(rime_inc_dir),
+    dependencies: cc.find_library('rime', dirs: rime_lib_dir),
+  )
+  deps = [rime_dep]
+endif
+
 # ubuntu jammy
 if meson.version().version_compare('<=0.61.2')
   py = import('python').find_installation()
@@ -15,7 +38,7 @@ conf_data.set(
   meson.project_version(),
   description: 'project version',
 )
-header_path = run_command('pkg-config', '--variable=includedir', 'rime', check: true).stdout().strip() + '/rime_api.h'
+header_path = rime_inc_dir + '/rime_api.h'
 configure_file(command: ['autopxd', header_path, 'rime_api.pxd'], output: 'rime_api.pxd')
 
 py.extension_module(


### PR DESCRIPTION
To build / use with native Windows, developer / user will need to download pre-built librime from [official releases](https://github.com/rime/librime/releases) and extract to a local path.

For building, set following environment variables, and build with `uv` inside command prompt for VS.
- `LIBRIME_INCLUDE_DIR` to the path containing `rime_api.h`, usually `include` folder of librime package
- `LIBRIME_LIB_DIR` to the path containing `rime.dll`, usually `lib` folder of librime package

For using, set `LIBRIME_LIB_DIR` is enough.